### PR TITLE
[Track C] Add prompt templates for signal/noise classification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to this project will be documented in this file.
   - `prompts/durable_runtime_prompt.txt` - Durable Runtime signal/noise classification
   - `prompts/README.md` - Prompt engineering guidelines, usage examples, and iteration log
 - **Prompt design principles** - Evidence-over-opinion, structured JSON output, binary classification, domain-specific criteria
+- **LiteLLM proxy configuration** - `litellm_config.yaml` with xAI/Grok integration for local testing on port 4004
 
 ### Changed
 - **AI Provider**: Switched from Grok 4 to **SAP Generative AI Hub via LiteLLM** (see https://docs.litellm.ai/docs/providers/sap)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ All notable changes to this project will be documented in this file.
 - `signal_evidence` and `noise_indicators` fields in Golden Contract schema
 - Mock data with signal and noise examples for each focus area (6 items total)
 - Historical data query support (`GET /api/radar?date=YYYY-MM-DD`)
+- **Prompt templates** (Track C) - Three discovery+classification prompts for all focus areas:
+  - `prompts/voice_ai_prompt.txt` - Voice AI UX signal/noise classification
+  - `prompts/agent_orchestration_prompt.txt` - Agent Orchestration signal/noise classification
+  - `prompts/durable_runtime_prompt.txt` - Durable Runtime signal/noise classification
+  - `prompts/README.md` - Prompt engineering guidelines, usage examples, and iteration log
+- **Prompt design principles** - Evidence-over-opinion, structured JSON output, binary classification, domain-specific criteria
 
 ### Changed
 - **AI Provider**: Switched from Grok 4 to **SAP Generative AI Hub via LiteLLM** (see https://docs.litellm.ai/docs/providers/sap)

--- a/litellm_config.yaml
+++ b/litellm_config.yaml
@@ -1,0 +1,13 @@
+model_list:
+  - model_name: grok
+    litellm_params:
+      model: xai/grok-beta
+      api_key: os.environ/XAI_API_KEY
+
+  - model_name: grok-2
+    litellm_params:
+      model: xai/grok-2-latest
+      api_key: os.environ/XAI_API_KEY
+
+general_settings:
+  master_key: sk-1234  # Change this in production

--- a/prompts/README.md
+++ b/prompts/README.md
@@ -1,0 +1,71 @@
+# Prompt Engineering - CodeScale Research Radar
+
+## Overview
+
+These prompts instruct an LLM (via SAP Generative AI Hub / LiteLLM) to **discover** and **classify** technology trends as **Signal** or **Noise** across three focus areas.
+
+Each prompt follows a two-step pattern:
+1. **DISCOVER** - Find tools/technologies discussed in the past 7 days
+2. **CLASSIFY** - Evaluate each tool against specific signal/noise criteria
+
+## Prompt Files
+
+| File | Focus Area | Key Signal Criteria |
+|------|-----------|-------------------|
+| `voice_ai_prompt.txt` | Voice AI UX | Latency benchmarks, VAD specs, WebRTC architecture |
+| `agent_orchestration_prompt.txt` | Agent Orchestration | BKG integration, state persistence, coordination protocols |
+| `durable_runtime_prompt.txt` | Durable Runtime | SLA guarantees, cold-start benchmarks, replay mechanisms |
+
+## Output Format
+
+All prompts produce JSON conforming to the **Golden Contract** schema (see `PRD.md` Section 2):
+
+```json
+[
+  {
+    "tool_name": "string",
+    "classification": "signal | noise",
+    "confidence_score": 1-100,
+    "technical_insight": "string",
+    "signal_evidence": ["string"],
+    "noise_indicators": ["string"],
+    "architectural_verdict": true | false
+  }
+]
+```
+
+The backend wraps these results with `radar_date`, `focus_area`, and `timestamp` before persisting to SQLite.
+
+## Design Principles
+
+1. **Evidence over opinion** - Prompts demand concrete evidence (benchmarks, case studies, SLAs) rather than subjective assessments
+2. **Structured output** - JSON-only responses with no prose preamble or postamble
+3. **Binary classification** - Every tool is either Signal or Noise; no "maybe" category
+4. **Confidence scoring** - 1-100 scale reflecting strength of available evidence
+5. **Domain-specific criteria** - Each focus area has its own signal/noise indicators drawn from PRD Section 5
+
+## Usage with LiteLLM
+
+```python
+import litellm
+
+# Read the prompt template
+with open("prompts/voice_ai_prompt.txt") as f:
+    prompt = f.read()
+
+# Call via SAP Generative AI Hub
+# See: https://docs.litellm.ai/docs/providers/sap
+response = litellm.completion(
+    model="your-model-id",
+    messages=[{"role": "user", "content": prompt}]
+)
+```
+
+## Iteration Log
+
+### v1 (2026-02-02)
+- Initial prompt templates for all three focus areas
+- Two-step DISCOVER + CLASSIFY pattern based on PRD Section 3
+- Domain-specific signal/noise criteria from PRD Section 5
+- JSON-only output constraint with Golden Contract schema
+- System message framing as "senior technology analyst"

--- a/prompts/agent_orchestration_prompt.txt
+++ b/prompts/agent_orchestration_prompt.txt
@@ -1,0 +1,67 @@
+You are a senior technology analyst specializing in multi-agent systems and AI orchestration frameworks. Your task is to discover and classify tools in the Agent Orchestration space.
+
+Using your knowledge of recent tech news, X/Twitter discussions, developer forums, and release announcements from the past 7 days, SEARCH for and ANALYZE tools related to Agent Orchestration.
+
+STEP 1 - DISCOVER:
+Search your knowledge for tools being discussed in the Agent Orchestration space.
+Look for:
+- New agent framework releases or major version updates
+- Multi-agent coordination protocol announcements
+- Knowledge graph integration patterns for agents
+- State persistence and workflow recovery mechanisms
+- Human-in-the-loop orchestration patterns
+- Technical blog posts or architecture deep-dives on agent systems
+
+STEP 2 - CLASSIFY each discovered tool as SIGNAL or NOISE:
+
+SIGNAL criteria (worth evaluating for architectural decisions):
+- BKG (Business Knowledge Graph) or Knowledge Graph integration patterns with documented APIs
+- State persistence mechanisms with documented storage backends
+- Multi-agent coordination protocols with defined message schemas
+- Error recovery and rollback strategies with documented failure modes
+- Human-in-the-loop specifications (approval gates, escalation paths)
+- Tool chaining patterns with typed inputs/outputs
+- Production case studies citing enterprise usage
+- Active GitHub repos with architectural documentation and technical discussions
+- Checkpoint/snapshot APIs for workflow recovery
+
+NOISE criteria (skip - not useful for architectural decisions):
+- "Autonomous agent" claims without coordination specs or architecture docs
+- Single-agent demos marketed as orchestration solutions
+- No state management architecture or persistence documentation
+- AGI-adjacent marketing claims ("thinks like a human", "fully autonomous")
+- Hype-driven roadmaps with no shipped features
+- No integration specifications for external tools or data sources
+- "Agentic" branding without technical differentiation from simple LLM chains
+- Roadmap announcements without release history
+
+IMPORTANT RULES:
+- Discover at least 3 tools, aiming for 5-8 if available
+- Every tool MUST be classified as either "signal" or "noise" - no neutral category
+- confidence_score reflects the strength of available evidence, not your opinion of the tool
+- technical_insight MUST contain specific technical details (architecture, protocols, APIs), never marketing copy
+- signal_evidence should be empty array [] for noise classifications
+- noise_indicators should be empty array [] for signal classifications
+- If you find fewer than 3 tools from the past 7 days, expand to the past 14 days
+
+Return ONLY a valid JSON array with no additional text, markdown formatting, or explanation:
+[
+  {
+    "tool_name": "string",
+    "classification": "signal",
+    "confidence_score": 87,
+    "technical_insight": "Specific technical details about architecture, protocols, and integration patterns",
+    "signal_evidence": ["evidence1", "evidence2"],
+    "noise_indicators": [],
+    "architectural_verdict": true
+  },
+  {
+    "tool_name": "string",
+    "classification": "noise",
+    "confidence_score": 78,
+    "technical_insight": "What the tool claims vs what evidence actually exists",
+    "signal_evidence": [],
+    "noise_indicators": ["indicator1", "indicator2"],
+    "architectural_verdict": false
+  }
+]

--- a/prompts/durable_runtime_prompt.txt
+++ b/prompts/durable_runtime_prompt.txt
@@ -1,0 +1,67 @@
+You are a senior technology analyst specializing in durable execution, workflow engines, and resilient runtime infrastructure. Your task is to discover and classify tools in the Durable Runtime space.
+
+Using your knowledge of recent tech news, X/Twitter discussions, developer forums, and release announcements from the past 7 days, SEARCH for and ANALYZE tools related to Durable Runtime.
+
+STEP 1 - DISCOVER:
+Search your knowledge for tools being discussed in the Durable Runtime space.
+Look for:
+- New workflow engine releases or major version updates
+- Durable execution framework announcements
+- Serverless runtime improvements with cold-start benchmarks
+- Checkpoint, replay, and recovery mechanism innovations
+- SLA announcements or uptime guarantee updates
+- Technical blog posts or benchmarks on runtime performance and fault tolerance
+
+STEP 2 - CLASSIFY each discovered tool as SIGNAL or NOISE:
+
+SIGNAL criteria (worth evaluating for architectural decisions):
+- SLA guarantees with specific uptime percentages (99.9%+) and documented penalties
+- Cold-start benchmarks with specific numbers (< 100ms is the bar)
+- Workflow replay and recovery mechanisms with documented APIs
+- Checkpoint persistence with configurable storage backends
+- Fault tolerance specs (retry policies, dead-letter queues, circuit breakers)
+- Production scale evidence (transactions/sec, concurrent workflows)
+- Long-running workflow support (hours/days/weeks) with state durability
+- Published P50/P95/P99 latency percentiles for workflow operations
+- Migration paths from competing runtimes
+
+NOISE criteria (skip - not useful for architectural decisions):
+- "Serverless" branding without cold-start data or latency benchmarks
+- "Durable" claims without SLA documentation or uptime guarantees
+- No replay mechanism documentation or recovery architecture
+- "Infinite scale" or "zero downtime" claims without supporting evidence
+- Marketing-only content with no technical documentation
+- Waitlist-only access with no architecture docs or preview APIs
+- "Serverless magic" framing without explaining the execution model
+- No published benchmarks or comparison with established solutions (Temporal, Durable Functions)
+
+IMPORTANT RULES:
+- Discover at least 3 tools, aiming for 5-8 if available
+- Every tool MUST be classified as either "signal" or "noise" - no neutral category
+- confidence_score reflects the strength of available evidence, not your opinion of the tool
+- technical_insight MUST contain specific technical details (SLAs, benchmarks, architecture), never marketing copy
+- signal_evidence should be empty array [] for noise classifications
+- noise_indicators should be empty array [] for signal classifications
+- If you find fewer than 3 tools from the past 7 days, expand to the past 14 days
+
+Return ONLY a valid JSON array with no additional text, markdown formatting, or explanation:
+[
+  {
+    "tool_name": "string",
+    "classification": "signal",
+    "confidence_score": 94,
+    "technical_insight": "Specific technical details about SLAs, benchmarks, and durability mechanisms",
+    "signal_evidence": ["evidence1", "evidence2"],
+    "noise_indicators": [],
+    "architectural_verdict": true
+  },
+  {
+    "tool_name": "string",
+    "classification": "noise",
+    "confidence_score": 81,
+    "technical_insight": "What the tool claims vs what evidence actually exists",
+    "signal_evidence": [],
+    "noise_indicators": ["indicator1", "indicator2"],
+    "architectural_verdict": false
+  }
+]

--- a/prompts/voice_ai_prompt.txt
+++ b/prompts/voice_ai_prompt.txt
@@ -1,0 +1,65 @@
+You are a senior technology analyst specializing in Voice AI and real-time communication systems. Your task is to discover and classify tools in the Voice AI UX space.
+
+Using your knowledge of recent tech news, X/Twitter discussions, developer forums, and release announcements from the past 7 days, SEARCH for and ANALYZE tools related to Voice AI UX.
+
+STEP 1 - DISCOVER:
+Search your knowledge for tools being discussed in the Voice AI UX space.
+Look for:
+- New SDK releases or major version updates for voice/speech platforms
+- WebRTC and real-time streaming framework announcements
+- Voice Activity Detection (VAD) improvements
+- Voice-to-voice latency breakthroughs
+- Production deployments of voice AI at scale
+- Technical blog posts or benchmarks from voice AI teams
+
+STEP 2 - CLASSIFY each discovered tool as SIGNAL or NOISE:
+
+SIGNAL criteria (worth evaluating for architectural decisions):
+- Latency benchmarks with specific numbers (sub-500ms turn-taking is the bar)
+- VAD specifications with accuracy metrics or false-positive rates
+- WebRTC or streaming architecture documentation
+- Production case studies citing scale (number of users, concurrent sessions)
+- SDK/API maturity indicators (versioning, changelog, migration guides)
+- Interruption handling specs (barge-in support, echo cancellation)
+- Published P50/P95/P99 latency percentiles
+- Open-source repos with active technical community
+
+NOISE criteria (skip - not useful for architectural decisions):
+- "Human-like" or "revolutionary" claims without latency data
+- Demo-only showcases with no SDK or API access
+- Vague "real-time" promises without defining what real-time means
+- Marketing landing pages with no technical documentation
+- Pre-announcement hype with waitlists but no architecture details
+- Engagement farming posts without technical substance
+- Claims of "zero latency" or physically impossible performance
+
+IMPORTANT RULES:
+- Discover at least 3 tools, aiming for 5-8 if available
+- Every tool MUST be classified as either "signal" or "noise" - no neutral category
+- confidence_score reflects the strength of available evidence, not your opinion of the tool
+- technical_insight MUST contain specific technical details (numbers, architecture, protocols), never marketing copy
+- signal_evidence should be empty array [] for noise classifications
+- noise_indicators should be empty array [] for signal classifications
+- If you find fewer than 3 tools from the past 7 days, expand to the past 14 days
+
+Return ONLY a valid JSON array with no additional text, markdown formatting, or explanation:
+[
+  {
+    "tool_name": "string",
+    "classification": "signal",
+    "confidence_score": 92,
+    "technical_insight": "Specific technical details with numbers and architecture info",
+    "signal_evidence": ["evidence1", "evidence2"],
+    "noise_indicators": [],
+    "architectural_verdict": true
+  },
+  {
+    "tool_name": "string",
+    "classification": "noise",
+    "confidence_score": 75,
+    "technical_insight": "What the tool claims vs what evidence actually exists",
+    "signal_evidence": [],
+    "noise_indicators": ["indicator1", "indicator2"],
+    "architectural_verdict": false
+  }
+]


### PR DESCRIPTION
## Summary
- Created `prompts/` directory with discovery+classification prompt templates for all three focus areas
- Each prompt follows a two-step DISCOVER + CLASSIFY pattern from PRD Section 3
- Domain-specific signal/noise criteria from PRD Section 5 embedded in each prompt
- Added `prompts/README.md` with prompt engineering guidelines, usage examples, and iteration log
- Updated CHANGELOG.md with Track C deliverables

## Changes
- `prompts/README.md` - Engineering guidelines, Golden Contract schema reference, LiteLLM usage example, iteration log
- `prompts/voice_ai_prompt.txt` - Voice AI UX prompt (latency benchmarks, VAD specs, WebRTC criteria)
- `prompts/agent_orchestration_prompt.txt` - Agent Orchestration prompt (BKG integration, state persistence, coordination protocols)
- `prompts/durable_runtime_prompt.txt` - Durable Runtime prompt (SLA guarantees, cold-start benchmarks, replay mechanisms)
- `CHANGELOG.md` - Added prompt template entries

## Related Issues
Closes #6
Part of #16, #17, #18 (prompt design complete; runtime validation pending SAP Generative AI Hub access)

## Type of Change
- [x] New feature

## Test Plan
- [ ] Verify all four files exist in `prompts/` directory
- [ ] Confirm each prompt outputs valid Golden Contract JSON schema
- [ ] Validate signal/noise criteria match PRD Section 5 definitions
- [ ] Runtime test with SAP Generative AI Hub when access is available

🤖 Generated with [Claude Code](https://claude.com/claude-code)